### PR TITLE
added support for files in flex-object storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.1.2.0
+## 11-01-2023
+
+1. [](#new)
+    * Added Support for files in flex-object data storage
+
 # v.1.1.0
 ## 05-06-2020
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ and add more form fields to the form by updating the copy. E.g. if you want to a
 
 The URL field will be available in your metadata form and you’ll be able edit the information.
 
+**Do not** remove or edit `filename` or `filepath` fields as the plugin requires them to run properly.
+
 ### Additional Page Specific Metadata Fields (v1.1 and later)
 
 You may also add page specific fields to a page’s frontmatter. *Note: The fields will be added to the form, not override the ones from the above mentioned config files:*

--- a/admin-addon-media-metadata.js
+++ b/admin-addon-media-metadata.js
@@ -16,6 +16,9 @@ $(function() {
 	// Append modal
 	$('body').append(adminAddonMediaMetadata.MODAL);
 
+	// add filepath to postable fields once
+	metadataFormFields.push('filepath');
+
 	$(document).off('click', '[data-dz-name], .dz-metadata-edit');
 	$(document).on('click', '[data-dz-name], .dz-metadata-edit', function(e) {
 		clickedElement = $(this);

--- a/admin-addon-media-metadata.js
+++ b/admin-addon-media-metadata.js
@@ -4,113 +4,113 @@
  */
 $(function() {
 
-	adminAddonMediaMetadata.metadata = {};
+    adminAddonMediaMetadata.metadata = {};
 
-	var clickedElement;
-	var fileName;
-	var $elementName;
-	var modal;
-	var $modal;
-	var isPageMedia = false;
+    var clickedElement;
+    var fileName;
+    var $elementName;
+    var modal;
+    var $modal;
+    var isPageMedia = false;
 
-	// Append modal
-	$('body').append(adminAddonMediaMetadata.MODAL);
+    // Append modal
+    $('body').append(adminAddonMediaMetadata.MODAL);
 
-	// add filepath to postable fields once
-	metadataFormFields.push('filepath');
+    // add filepath to postable fields once
+    metadataFormFields.push('filepath');
 
-	$(document).off('click', '[data-dz-name], .dz-metadata-edit');
-	$(document).on('click', '[data-dz-name], .dz-metadata-edit', function(e) {
-		clickedElement = $(this);
-		modal = $.remodal.lookup[$('[data-remodal-id=modal-admin-addon-media-metadata]').data('remodal')];
-		$modal = modal.$modal;
-		modal.open();
+    $(document).off('click', '[data-dz-name], .dz-metadata-edit');
+    $(document).on('click', '[data-dz-name], .dz-metadata-edit', function(e) {
+        clickedElement = $(this);
+        modal = $.remodal.lookup[$('[data-remodal-id=modal-admin-addon-media-metadata]').data('remodal')];
+        $modal = modal.$modal;
+        modal.open();
 
-		// Populate fields
-		elementName = clickedElement.closest('.dz-preview').find('[data-dz-name]')
-		fileName = elementName.text();
-		$('[name=filename]', $modal).val(fileName);
-		if (mediaListOnLoad[fileName] !== undefined) {
-			for (var i = 0; i < metadataFormFields.length; i++) {
-				$('[name=' + metadataFormFields[i] + ']', $modal).val(mediaListOnLoad[fileName][metadataFormFields[i]]);
-			}
-		} else {
-			for (var i = 0; i < metadataFormFields.length; i++) {
-				$('[name=' + metadataFormFields[i] + ']', $modal).val('');
-			}
-		}
-		$modal.find('form span.filename').text(fileName);
+        // Populate fields
+        elementName = clickedElement.closest('.dz-preview').find('[data-dz-name]')
+        fileName = elementName.text();
+        $('[name=filename]', $modal).val(fileName);
+        if (mediaListOnLoad[fileName] !== undefined) {
+            for (var i = 0; i < metadataFormFields.length; i++) {
+                $('[name=' + metadataFormFields[i] + ']', $modal).val(mediaListOnLoad[fileName][metadataFormFields[i]]);
+            }
+        } else {
+            for (var i = 0; i < metadataFormFields.length; i++) {
+                $('[name=' + metadataFormFields[i] + ']', $modal).val('');
+            }
+        }
+        $modal.find('form span.filename').text(fileName);
 
-		// Reset loading state
-		$('.loading', $modal).addClass('hidden');
+        // Reset loading state
+        $('.loading', $modal).addClass('hidden');
 //		$('.button', $modal).removeClass('hidden').css('visibility', 'hidden');
-		$('.button', $modal).removeClass('hidden');
+        $('.button', $modal).removeClass('hidden');
 
-		isPageMedia = !clickedElement.closest('.dz-preview').hasClass('dz-no-editor');
-		$modal.find('.block-toggle').toggleClass('hidden', !isPageMedia);
-		$modal.find('.page-media-info').toggleClass('hidden', !isPageMedia);
-		$modal.find('.non-page-media-info').toggleClass('hidden', isPageMedia);
-	});
+        isPageMedia = !clickedElement.closest('.dz-preview').hasClass('dz-no-editor');
+        $modal.find('.block-toggle').toggleClass('hidden', !isPageMedia);
+        $modal.find('.page-media-info').toggleClass('hidden', !isPageMedia);
+        $modal.find('.non-page-media-info').toggleClass('hidden', isPageMedia);
+    });
 
-	/**
-	 * add the new data dynamically to mediaListOnLoad JSON object
-	 * for newly uploaded media files as well as for “older” files, overwriting the data already in that JSON object
-	 * and save it in the YAML file
-	 * Variables from above ($(document).on), like fileName and $modal are still available
-	 */
-	$(document).on('click', '[data-remodal-id=modal-admin-addon-media-metadata] .button', function(e) {
-		// hiding the button and showing the loading icon
-		$('.loading', $modal).removeClass('hidden');
-		$('.button', $modal).addClass('hidden');
+    /**
+     * add the new data dynamically to mediaListOnLoad JSON object
+     * for newly uploaded media files as well as for “older” files, overwriting the data already in that JSON object
+     * and save it in the YAML file
+     * Variables from above ($(document).on), like fileName and $modal are still available
+     */
+    $(document).on('click', '[data-remodal-id=modal-admin-addon-media-metadata] .button', function(e) {
+        // hiding the button and showing the loading icon
+        $('.loading', $modal).removeClass('hidden');
+        $('.button', $modal).addClass('hidden');
 
-		// create the file object for newly uploaded files
-		if (mediaListOnLoad[fileName] === undefined) {
-			mediaListOnLoad[fileName] = new Object();
-			mediaListOnLoad[fileName]['filename'] = fileName;
-		}
+        // create the file object for newly uploaded files
+        if (mediaListOnLoad[fileName] === undefined) {
+            mediaListOnLoad[fileName] = new Object();
+            mediaListOnLoad[fileName]['filename'] = fileName;
+        }
 
-		// Do request with JS Fetch API: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
-		var data = new FormData();
-		data.append('filename', fileName);
-		data.append('admin-nonce', GravAdmin.config.admin_nonce);
+        // Do request with JS Fetch API: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+        var data = new FormData();
+        data.append('filename', fileName);
+        data.append('admin-nonce', GravAdmin.config.admin_nonce);
 
-		// add the new values to mediaListOnLoad (for later updates before page reload)
-		// append the new values to the FormData (data.append)
-		for (var i = 0; i < metadataFormFields.length; i++) {
-			var newVal = $('[name=' + metadataFormFields[i] + ']', $modal).val();
-			mediaListOnLoad[fileName][metadataFormFields[i]] = newVal;
-			data.append(metadataFormFields[i], newVal);
-		}
+        // add the new values to mediaListOnLoad (for later updates before page reload)
+        // append the new values to the FormData (data.append)
+        for (var i = 0; i < metadataFormFields.length; i++) {
+            var newVal = $('[name=' + metadataFormFields[i] + ']', $modal).val();
+            mediaListOnLoad[fileName][metadataFormFields[i]] = newVal;
+            data.append(metadataFormFields[i], newVal);
+        }
 
-		fetch(adminAddonMediaMetadata.PATH, { method: 'POST', body: data, credentials: 'same-origin' })
-			//.then(res => res.json())
-			.then(result => {
-				if (result.error) {
-					var alertModal = $.remodal.lookup[$('[data-remodal-id=modal-admin-addon-media-metadata-alert]').data('remodal')];
-					alertModal.open();
-					$('p', alertModal.$modal).html(result.error.msg);
-					return;
-				}
+        fetch(adminAddonMediaMetadata.PATH, { method: 'POST', body: data, credentials: 'same-origin' })
+            //.then(res => res.json())
+            .then(result => {
+                if (result.error) {
+                    var alertModal = $.remodal.lookup[$('[data-remodal-id=modal-admin-addon-media-metadata-alert]').data('remodal')];
+                    alertModal.open();
+                    $('p', alertModal.$modal).html(result.error.msg);
+                    return;
+                }
 
-				modal.close();
-			});
-	});
+                modal.close();
+            });
+    });
 
-	// adding the “edit metadata” button next to all media files
-	setInterval(function addMetadataButton() {
-		$('.dz-preview').each(function(i, dz) {
-			if ($(this).find('.dz-metadata-edit').length == 0) {
-				var editButton = document.createElement('a');
-				//editButton.href = 'javascript:undefined;';
-				editButton.title = adminAddonMediaMetadataButton;
-				editButton.className = 'dz-metadata-edit';
-				editButton.innerText = adminAddonMediaMetadataButton;
-				var fileName = $(this).find('[data-dz-name]').text();
-				editButton.setAttribute('data-filename', fileName);
-				$(this).append(editButton);
-			}
-			$(this).find('.dz-metadata').remove();
-		});
-	}, 1000);
+    // adding the “edit metadata” button next to all media files
+    setInterval(function addMetadataButton() {
+        $('.dz-preview').each(function(i, dz) {
+            if ($(this).find('.dz-metadata-edit').length == 0) {
+                var editButton = document.createElement('a');
+                //editButton.href = 'javascript:undefined;';
+                editButton.title = adminAddonMediaMetadataButton;
+                editButton.className = 'dz-metadata-edit';
+                editButton.innerText = adminAddonMediaMetadataButton;
+                var fileName = $(this).find('[data-dz-name]').text();
+                editButton.setAttribute('data-filename', fileName);
+                $(this).append(editButton);
+            }
+            $(this).find('.dz-metadata').remove();
+        });
+    }, 1000);
 });
 

--- a/admin-addon-media-metadata.yaml
+++ b/admin-addon-media-metadata.yaml
@@ -7,10 +7,15 @@ metadata_form:
     name: filename
     readonly: true
 
+  - type: hidden
+    title: PLUGIN_ADMIN_ADDON_MEDIA_METADATA.FILEPATH
+    name: filepath
+    readonly: true
+
   - type: text
     label: PLUGIN_ADMIN_ADDON_MEDIA_METADATA.TITLE
     name: title
-    
+
   - type: text
     label: PLUGIN_ADMIN_ADDON_MEDIA_METADATA.ALT
     name: alt

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Admin Addon Media Metadata
-version: 1.1.0
+version: 1.2.0
 description: 'This plugin is an addon for the Grav CMS Admin plugin and lets you add and edit metadata for media files'
 icon: plug
 author:

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -2,6 +2,7 @@ PLUGIN_ADMIN_ADDON_MEDIA_METADATA:
   BUTTON: Metadaten ändern
   FORM_HEADER: Metadaten für Mediendatei ändern
   FILENAME: Dateiname
+  FILEPATH: Dateipfad
   TITLE: Titel
   ALT: Beschreibung für den Fall, dass die Datei nicht angezeigt werden kann (alternativer Text)
   CAPTION: Bildunterschrift

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -2,6 +2,7 @@ PLUGIN_ADMIN_ADDON_MEDIA_METADATA:
   BUTTON: Edit metadata
   FORM_HEADER: Edit metadata for media file
   FILENAME: Filename
+  FILEPATH: File path
   TITLE: Title
   ALT: Describe the media file for when it can’t be displayed (alternative text)
   CAPTION: Caption

--- a/languages/fr.yaml
+++ b/languages/fr.yaml
@@ -2,6 +2,7 @@ PLUGIN_ADMIN_ADDON_MEDIA_METADATA:
   BUTTON: Editer les métadonnées pour ce média
   FORM_HEADER: Editer les métadonnées pour ce média
   FILENAME: Nom du fichier
+  FILEPATH: Chemin du fichier
   TITLE: Titre
   ALT: Description du média lorsqu'il ne peut être affiché (texte alternatif)
   CAPTION: Légende


### PR DESCRIPTION
I used some time to make this work with flex-object but it's finally done.

* Works now with images attached to flex-objects
* Update task endpoint URL fixed (was returning 404 despite successful execution)
* Version number raised in blueprint
* Changelog continued
* Readme enhanced
* Translations enhanced (despite new form field is hidden)

Please create a new release after merging, so the grav plugin directory/gpm will get updated too.

NB: In the second commit I updated the file format of the JavaScript file, the relevant code changes to it can be seen in the first commit.

Referencing issue #17

P.S.: If you need help maintaining this plugin more actively, let me know @clivebeckett.