### PR TITLE
Fix crash when custom metadata fields have no name defined

### DIFF
--- a/admin-addon-media-metadata.php
+++ b/admin-addon-media-metadata.php
@@ -113,7 +113,7 @@ class AdminAddonMediaMetadataPlugin extends Plugin
         // clean up legacy configs
         foreach ( $formFields['fields'] as $key => $field )
         {
-            if ( in_array( $field['name'], [ 'filename', 'filepath' ] ) )
+            if ( array_key_exists('name', $field) && in_array( $field['name'], [ 'filename', 'filepath' ] ) )
             {
                 unset( $formFields['fields'][$key] );
             }


### PR DESCRIPTION
Refer #31.

Decided to simply check for it rather than require the `name` property because this approach:

* is much simpler,
* doesn't break existing sites, _and_
* there is no other reason to require the `name` property is set.